### PR TITLE
replace espowerify with babel-plugin-espower

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -11,7 +11,9 @@ module.exports = function(config) {
         },
 
         browserify: {
-            transform: ['babelify', {plugins: ['babel-plugin-espower']}]
+            transform: [
+	            ['babelify', {plugins: ['babel-plugin-espower']}]
+	        ]
         },
 
         browsers: ['Chrome'],

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -11,7 +11,7 @@ module.exports = function(config) {
         },
 
         browserify: {
-            transform: ['babelify', 'espowerify']
+            transform: ['babelify', {plugins: ['babel-plugin-espower']}]
         },
 
         browsers: ['Chrome'],

--- a/package.json
+++ b/package.json
@@ -24,13 +24,14 @@
     "svg4everybody": "0.0.2"
   },
   "devDependencies": {
+    "babel-core": "^5.1.11",
     "babel-eslint": "^3.0.1",
+    "babel-plugin-espower": "^0.2.1",
     "babelify": "^6.0.2",
     "browser-sync": "^2.6.4",
     "browserify": "^9.0.8",
     "del": "^1.1.1",
     "eslint": "^0.19.0",
-    "espowerify": "^0.10.0",
     "gulp": "^3.8.11",
     "gulp-cssnext": "^1.0.0",
     "gulp-eslint": "^0.9.0",

--- a/test/greeting.js
+++ b/test/greeting.js
@@ -1,8 +1,6 @@
 'use strict';
 
-// it doesn't seem to work with `import`
-// import assert from 'power-assert';
-let assert = require('power-assert');
+import assert from 'power-assert';
 
 import greeting from '../src/js/greeting';
 


### PR DESCRIPTION
Hi, here is the config to enable ES6 module syntax.

refs [:bug: · pocotan001/seed@91d844c](https://github.com/pocotan001/seed/commit/91d844c589b6443f24a13b8063ff7cac0870ab5c#commitcomment-10820236)

Thanks!
